### PR TITLE
Adds ability to update tags for SQS Queues

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-03-22T21:50:32Z"
-  build_hash: fa24753ea8b657d8815ae3eac7accd0958f5f9fb
-  go_version: go1.19
-  version: v0.25.0
+  build_date: "2023-03-31T17:11:13Z"
+  build_hash: a6ae2078e57187b2daf47978bc07bd67072d2cba
+  go_version: go1.19.4
+  version: v0.25.0-1-ga6ae207
 api_directory_checksum: 3741e855a47295ce5921a70cf58ca4fc020fae5d
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: 87f1622e6270c4a4de11ae7c17e3eeffe2fa5114
+  file_checksum: 6bd821b4798fa3e3be997dc77c1b0f98bd1c8f6b
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -7,6 +7,11 @@ resources:
           AttributeNames:
             values:
               - All
+    hooks:
+      sdk_get_attributes_post_set_output:
+        template_path: hooks/queue/sdk_get_attributes_post_set_output.go.tpl
+      sdk_update_pre_build_request:
+        template_path: hooks/queue/sdk_update_pre_build_request.go.tpl
     fields:
       DelaySeconds:
         is_attribute: true
@@ -58,10 +63,6 @@ resources:
         is_required: true
         is_immutable: true
         type: string
-      Tags:
-        compare:
-          is_ignored: true
       QueueUrl:
         is_readonly: true
         is_primary_key: true
-      

--- a/generator.yaml
+++ b/generator.yaml
@@ -7,6 +7,11 @@ resources:
           AttributeNames:
             values:
               - All
+    hooks:
+      sdk_get_attributes_post_set_output:
+        template_path: hooks/queue/sdk_get_attributes_post_set_output.go.tpl
+      sdk_update_pre_build_request:
+        template_path: hooks/queue/sdk_update_pre_build_request.go.tpl
     fields:
       DelaySeconds:
         is_attribute: true
@@ -58,10 +63,6 @@ resources:
         is_required: true
         is_immutable: true
         type: string
-      Tags:
-        compare:
-          is_ignored: true
       QueueUrl:
         is_readonly: true
         is_primary_key: true
-      

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -145,10 +145,7 @@ spec:
                             blockOwnerDeletion:
                               description: If true, AND if the owner has the "foregroundDeletion"
                                 finalizer, then the owner cannot be deleted from the
-                                key-value store until this reference is removed. See
-                                https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
-                                for how the garbage collector interacts with this
-                                field and enforces the foreground deletion. Defaults
+                                key-value store until this reference is removed. Defaults
                                 to false. To set this field, a user needs "delete"
                                 permission of the owner, otherwise 422 (Unprocessable
                                 Entity) will be returned.

--- a/pkg/resource/queue/delta.go
+++ b/pkg/resource/queue/delta.go
@@ -126,6 +126,9 @@ func newResourceDelta(
 			delta.Add("Spec.RedrivePolicy", a.ko.Spec.RedrivePolicy, b.ko.Spec.RedrivePolicy)
 		}
 	}
+	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.VisibilityTimeout, b.ko.Spec.VisibilityTimeout) {
 		delta.Add("Spec.VisibilityTimeout", a.ko.Spec.VisibilityTimeout, b.ko.Spec.VisibilityTimeout)
 	} else if a.ko.Spec.VisibilityTimeout != nil && b.ko.Spec.VisibilityTimeout != nil {

--- a/pkg/resource/queue/hooks.go
+++ b/pkg/resource/queue/hooks.go
@@ -1,0 +1,134 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package queue
+
+import (
+	"context"
+
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	svcsdk "github.com/aws/aws-sdk-go/service/sqs"
+)
+
+// syncTags examines the Tags in the supplied Queue and calls the
+// ListQueueTags, TagQueue and UntagQueue APIs to ensure that the set of
+// associated Tags  stays in sync with the Queue.Spec.Tags
+func (rm *resourceManager) syncTags(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.syncTags")
+	defer func() { exit(err) }()
+	toAdd := map[string]*string{}
+	toDelete := []*string{}
+
+	existingTags := latest.ko.Spec.Tags
+
+	for k, v := range desired.ko.Spec.Tags {
+		if ev, found := existingTags[k]; !found || *ev != *v {
+			toAdd[k] = v
+		}
+	}
+
+	for k, _ := range existingTags {
+		if _, found := desired.ko.Spec.Tags[k]; !found {
+			deleteKey := k
+			toDelete = append(toDelete, &deleteKey)
+		}
+	}
+
+	if len(toAdd) > 0 {
+		for k, v := range toAdd {
+			rlog.Debug("adding tag to queue", "key", k, "value", *v)
+		}
+		if err = rm.addTags(ctx, desired, toAdd); err != nil {
+			return err
+		}
+	}
+	if len(toDelete) > 0 {
+		for _, k := range toDelete {
+			rlog.Debug("removing tag from queue", "key", *k)
+		}
+		if err = rm.removeTags(ctx, desired, toDelete); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// getTags returns the list of tags to the Queue
+func (rm *resourceManager) getTags(
+	ctx context.Context,
+	r *resource,
+) (map[string]*string, error) {
+	var err error
+	var resp *svcsdk.ListQueueTagsOutput
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.getTags")
+	defer func() { exit(err) }()
+
+	input := &svcsdk.ListQueueTagsInput{}
+	input.QueueUrl = r.ko.Status.QueueURL
+
+	// NOTE(jaypipes): Unlike many other ListTags APIs, SQS's is not
+	// paginated...
+	resp, err = rm.sdkapi.ListQueueTagsWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_MANY", "ListQueueTags", err)
+	if err != nil || resp == nil {
+		return nil, err
+	}
+	// and the output's Tags field is actually a map[string]*string... go
+	// figure :)
+	return resp.Tags, err
+}
+
+// addTags adds the supplied Tags to the supplied Queue resource
+func (rm *resourceManager) addTags(
+	ctx context.Context,
+	r *resource,
+	tags map[string]*string,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.addTag")
+	defer func() { exit(err) }()
+
+	input := &svcsdk.TagQueueInput{}
+	input.QueueUrl = r.ko.Status.QueueURL
+	input.Tags = tags
+
+	_, err = rm.sdkapi.TagQueueWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "TagQueue", err)
+	return err
+}
+
+// removeTags removes the supplied Tags from the supplied Queue resource
+func (rm *resourceManager) removeTags(
+	ctx context.Context,
+	r *resource,
+	tagKeys []*string, // the set of tag keys to delete
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.removeTag")
+	defer func() { exit(err) }()
+
+	input := &svcsdk.UntagQueueInput{}
+	input.QueueUrl = r.ko.Status.QueueURL
+	input.TagKeys = tagKeys
+
+	_, err = rm.sdkapi.UntagQueueWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "UntagQueue", err)
+	return err
+}

--- a/templates/hooks/queue/sdk_get_attributes_post_set_output.go.tpl
+++ b/templates/hooks/queue/sdk_get_attributes_post_set_output.go.tpl
@@ -1,0 +1,5 @@
+	if tags, err := rm.getTags(ctx, r); err != nil {
+		return nil, err
+	} else {
+		ko.Spec.Tags = tags
+	}

--- a/templates/hooks/queue/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/queue/sdk_update_pre_build_request.go.tpl
@@ -1,0 +1,8 @@
+	if delta.DifferentAt("Spec.Tags") {
+		if err := rm.syncTags(ctx, desired, latest); err != nil {
+			return nil, err
+		}
+	}
+	if !delta.DifferentExcept("Spec.Tags") {
+		return desired, nil
+	}

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@835781dcbb39e2220e68a659dd771ce4bd9b1ac0
+acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@cee228cabae1c65599df8f87b0860d161f8093bf

--- a/test/e2e/resources/queue.yaml
+++ b/test/e2e/resources/queue.yaml
@@ -5,3 +5,5 @@ metadata:
 spec:
   queueName: $QUEUE_NAME
   delaySeconds: "0"
+  tags:
+    key1: val1

--- a/test/e2e/sqsqueue.py
+++ b/test/e2e/sqsqueue.py
@@ -1,0 +1,132 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Utilities for working with Queue resources"""
+
+import datetime
+import json
+import time
+
+import boto3
+import pytest
+
+DEFAULT_WAIT_UNTIL_EXISTS_TIMEOUT_SECONDS = 60*10
+DEFAULT_WAIT_UNTIL_EXISTS_INTERVAL_SECONDS = 15
+DEFAULT_WAIT_UNTIL_DELETED_TIMEOUT_SECONDS = 60*10
+DEFAULT_WAIT_UNTIL_DELETED_INTERVAL_SECONDS = 15
+
+
+def wait_until_exists(
+        queue_name: str,
+        timeout_seconds: int = DEFAULT_WAIT_UNTIL_EXISTS_TIMEOUT_SECONDS,
+        interval_seconds: int = DEFAULT_WAIT_UNTIL_EXISTS_INTERVAL_SECONDS,
+    ) -> None:
+    """Waits until a Queue with a supplied name is returned from SQS GetQueue
+    API.
+
+    Usage:
+        from e2e.queue import wait_until_exists
+
+        wait_until_exists(queue_name)
+
+    Raises:
+        pytest.fail upon timeout
+    """
+    now = datetime.datetime.now()
+    timeout = now + datetime.timedelta(seconds=timeout_seconds)
+
+    while True:
+        if datetime.datetime.now() >= timeout:
+            pytest.fail(
+                "Timed out waiting for Queue to exist "
+                "in SQS API"
+            )
+        time.sleep(interval_seconds)
+
+        latest = get_queue_url(queue_name)
+        if latest is not None:
+            break
+
+
+def wait_until_deleted(
+        queue_name: str,
+        timeout_seconds: int = DEFAULT_WAIT_UNTIL_DELETED_TIMEOUT_SECONDS,
+        interval_seconds: int = DEFAULT_WAIT_UNTIL_DELETED_INTERVAL_SECONDS,
+    ) -> None:
+    """Waits until a Queue with a supplied ID is no longer returned from
+    the SQS API.
+
+    Usage:
+        from e2e.queue import wait_until_deleted
+
+        wait_until_deleted(queue_name)
+
+    Raises:
+        pytest.fail upon timeout
+    """
+    now = datetime.datetime.now()
+    timeout = now + datetime.timedelta(seconds=timeout_seconds)
+
+    while True:
+        if datetime.datetime.now() >= timeout:
+            pytest.fail(
+                "Timed out waiting for Queue to be "
+                "deleted in SQS API"
+            )
+        time.sleep(interval_seconds)
+
+        latest = get_queue_url(queue_name)
+        if latest is None:
+            break
+
+
+def get_queue_url(queue_name):
+    """Returns the URL for a supplied Queue name.
+
+    If no such Queue exists, returns None.
+    """
+    c = boto3.client('sqs')
+    try:
+        resp = c.get_queue_url(QueueName=queue_name)
+        return resp['QueueUrl']
+    except c.exceptions.QueueDoesNotExist:
+        return None
+
+
+def get_attributes(queue_url):
+    """Returns a dict containing the Queue attributes from the SQS API.
+
+    If no such Queue exists, returns None.
+    """
+    c = boto3.client('sqs')
+    try:
+        resp = c.get_queue_attributes(
+            QueueUrl=queue_url, AttributeNames=['All'],
+        )
+        return resp['Attributes']
+    except c.exceptions.QueueDoesNotExist:
+        return None
+
+
+def get_tags(queue_url):
+    """Returns a list containing the tags that have been associated to the
+    supplied Queue.
+
+    If no such Queue exists, returns None.
+    """
+    c = boto3.client('sqs')
+    try:
+        resp = c.list_queue_tags(QueueUrl=queue_url)
+        return resp['Tag']
+    except c.exceptions.QueueDoesNotExist:
+        return None

--- a/test/e2e/sqsqueue.py
+++ b/test/e2e/sqsqueue.py
@@ -119,7 +119,7 @@ def get_attributes(queue_url):
 
 
 def get_tags(queue_url):
-    """Returns a list containing the tags that have been associated to the
+    """Returns a dict containing the tags that have been associated to the
     supplied Queue.
 
     If no such Queue exists, returns None.
@@ -127,6 +127,6 @@ def get_tags(queue_url):
     c = boto3.client('sqs')
     try:
         resp = c.list_queue_tags(QueueUrl=queue_url)
-        return resp['Tag']
+        return resp['Tags']
     except c.exceptions.QueueDoesNotExist:
         return None

--- a/test/e2e/tests/test_queue.py
+++ b/test/e2e/tests/test_queue.py
@@ -14,18 +14,16 @@
 """Integration tests for the Queue API.
 """
 
-import boto3
 import pytest
 import time
 import logging
-from typing import Dict, Tuple
 
 from acktest.resources import random_suffix_name
-from acktest.aws.identity import get_region
 from acktest.k8s import resource as k8s
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_sqs_resource
 from e2e.replacement_values import REPLACEMENT_VALUES
 from e2e.bootstrap_resources import get_bootstrap_resources
+from e2e import sqsqueue
 
 RESOURCE_PLURAL = "queues"
 
@@ -33,65 +31,64 @@ CREATE_WAIT_AFTER_SECONDS = 5
 UPDATE_WAIT_AFTER_SECONDS = 5
 DELETE_WAIT_AFTER_SECONDS = 60
 
+@pytest.fixture(scope="module")
+def simple_queue():
+    resource_name = random_suffix_name("sqs-queue", 24)
+
+    resources = get_bootstrap_resources()
+    logging.debug(resources)
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["QUEUE_NAME"] = resource_name
+
+    # Load Queue CR
+    resource_data = load_sqs_resource(
+        "queue",
+        additional_replacements=replacements,
+    )
+    logging.debug(resource_data)
+
+    # Create k8s resource
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+        resource_name, namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+
+    sqsqueue.wait_until_exists(resource_name)
+
+    yield cr, ref
+
+    # Delete k8s resource
+    _, deleted = k8s.delete_custom_resource(
+        ref,
+        period_length=DELETE_WAIT_AFTER_SECONDS,
+    )
+    assert deleted
+
+    sqsqueue.wait_until_deleted(resource_name)
+
+
 @service_marker
 @pytest.mark.canary
 class TestQueue:
-    def get_queue(self, sqs_client, queue_name: str) -> dict:
-        try:
-            resp = sqs_client.get_queue_url(
-                QueueName=queue_name
-            )
-            return resp
-
-        except Exception as e:
-            logging.debug(e)
-            return None
-
-    def queue_exists(self, sqs_client, queue_name: str) -> bool:
-        return self.get_queue(sqs_client, queue_name) is not None
-
-    def test_smoke(self, sqs_client):
-        resource_name = random_suffix_name("sqs-queue", 24)
-
-        resources = get_bootstrap_resources()
-        logging.debug(resources)
-
-        replacements = REPLACEMENT_VALUES.copy()
-        replacements["QUEUE_NAME"] = resource_name
-        replacements["AWS_REGION"] = get_region()
-
-        # Load Queue CR
-        resource_data = load_sqs_resource(
-            "queue",
-            additional_replacements=replacements,
-        )
-        logging.debug(resource_data)
-
-        # Create k8s resource
-        ref = k8s.CustomResourceReference(
-            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
-            resource_name, namespace="default",
-        )
-        k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
-
-        assert cr is not None
-        assert k8s.get_resource_exists(ref)
+    def test_crud(self, simple_queue):
+        res, ref = simple_queue
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        # Update the tags associated with the Queue and verify the update is
+        # reflected in the SQS API
+        cr = k8s.get_resource(ref)
+        assert cr is not None
+        assert 'spec' in cr
+        assert 'delaySeconds' in cr['spec']
+        assert cr['spec']['delaySeconds'] == "0"
+        assert 'status' in cr
+        assert 'queueURL' in cr['status']
+        queue_url = cr['status']['queueURL']
 
-        # Check Queue exists
-        exists = self.queue_exists(sqs_client, resource_name)
-        assert exists
-
-        # Delete k8s resource
-        _, deleted = k8s.delete_custom_resource(ref)
-        assert deleted is True
-
-        time.sleep(DELETE_WAIT_AFTER_SECONDS)
-
-        # Check Queue doesn't exist
-        exists = self.queue_exists(sqs_client, resource_name)
-        assert not exists
+        latest_attrs = sqsqueue.get_attributes(queue_url)
+        assert 'DelaySeconds' in latest_attrs
+        assert latest_attrs['DelaySeconds'] == "0"


### PR DESCRIPTION
Brings in the the ability to update and delete tags from an SQS Queue
using the code hook points recently added to the sdkUpdate method for
SetAttributes-based APIs like SNS/SQS.
    
Issue aws-controllers-k8s/community#1541

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
