### PR TITLE
add test to verify attribute updates

### DIFF
--- a/test/e2e/tests/test_queue.py
+++ b/test/e2e/tests/test_queue.py
@@ -94,6 +94,18 @@ class TestQueue:
         assert 'DelaySeconds' in latest_attrs
         assert latest_attrs['DelaySeconds'] == "0"
 
+        # Test updating one of the attributes...
+        new_delay = "10"
+        updates = {
+            "spec": {"delaySeconds": new_delay},
+        }
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+
+        latest_attrs = sqsqueue.get_attributes(queue_url)
+        assert 'DelaySeconds' in latest_attrs
+        assert latest_attrs['DelaySeconds'] == new_delay
+
         # Test updating tags...
         assert 'tags' in cr['spec']
         assert len(cr['spec']['tags']) == 1


### PR DESCRIPTION
Adds a simple e2e test that updates the delaySeconds field/attribute and verifies the change is reflected in the AWS API.

Closes issue aws-controllers-k8s/community#1541

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
