### PR TITLE
Fix: malformed input when update without atrributes changes

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2023-09-14T23:52:46Z"
+  build_date: "2023-12-16T08:34:38Z"
   build_hash: 892f29d00a4c4ad21a2fa32919921de18190979d
   go_version: go1.21.0
   version: v0.27.1
@@ -7,7 +7,7 @@ api_directory_checksum: 4538a2a4e75334bd4ab5ebd8dd9f73b69662d197
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: 9eac8d3730cfe212c3a88aa5173b22de93c2d0b7
+  file_checksum: c373e8ad8d189318656ef1f90a73a1f3e319bf89
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -14,6 +14,8 @@ resources:
         template_path: hooks/queue/sdk_get_attributes_post_set_output.go.tpl
       sdk_update_pre_build_request:
         template_path: hooks/queue/sdk_update_pre_build_request.go.tpl
+      sdk_update_post_build_request:
+        template_path: hooks/queue/sdk_update_post_build_request.go.tpl
     fields:
       DelaySeconds:
         is_attribute: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -14,6 +14,8 @@ resources:
         template_path: hooks/queue/sdk_get_attributes_post_set_output.go.tpl
       sdk_update_pre_build_request:
         template_path: hooks/queue/sdk_update_pre_build_request.go.tpl
+      sdk_update_post_build_request:
+        template_path: hooks/queue/sdk_update_post_build_request.go.tpl
     fields:
       DelaySeconds:
         is_attribute: true

--- a/pkg/resource/queue/sdk.go
+++ b/pkg/resource/queue/sdk.go
@@ -292,6 +292,14 @@ func (rm *resourceManager) sdkUpdate(
 	if err != nil {
 		return nil, err
 	}
+	// note(Julian-Chu): SetAttributes API without any attributes
+	// will return MalformedInput(message: End of list found where not expected) error. We need to set minimal one default value,
+	// if there are no attributes in the input
+	if len(input.Attributes) == 0 {
+		input.Attributes = map[string]*string{
+			"DelaySeconds": latest.ko.Spec.DelaySeconds,
+		}
+	}
 
 	// NOTE(jaypipes): SetAttributes calls return a response but they don't
 	// contain any useful information. Instead, below, we'll be returning a

--- a/pkg/resource/queue/sdk.go
+++ b/pkg/resource/queue/sdk.go
@@ -293,8 +293,9 @@ func (rm *resourceManager) sdkUpdate(
 		return nil, err
 	}
 	// note(Julian-Chu): SetAttributes API without any attributes
-	// will return MalformedInput(message: End of list found where not expected) error. We need to set minimal one default value,
-	// if there are no attributes in the input
+	// will return MalformedInput(message: End of list found where not expected) error.
+	// if there are no attributes in the input,
+	// We need to set minimal one default value, or use customUpdate to skip api call.
 	if len(input.Attributes) == 0 {
 		input.Attributes = map[string]*string{
 			"DelaySeconds": latest.ko.Spec.DelaySeconds,

--- a/templates/hooks/queue/sdk_update_post_build_request.go.tpl
+++ b/templates/hooks/queue/sdk_update_post_build_request.go.tpl
@@ -1,0 +1,8 @@
+	// note(Julian-Chu): SetAttributes API without any attributes
+	// will return MalformedInput(message: End of list found where not expected) error. We need to set minimal one default value,
+	// if there are no attributes in the input
+	if len(input.Attributes) == 0 {
+		input.Attributes = map[string]*string{
+			"DelaySeconds": latest.ko.Spec.DelaySeconds,
+		}
+	}

--- a/templates/hooks/queue/sdk_update_post_build_request.go.tpl
+++ b/templates/hooks/queue/sdk_update_post_build_request.go.tpl
@@ -1,6 +1,7 @@
 	// note(Julian-Chu): SetAttributes API without any attributes
-	// will return MalformedInput(message: End of list found where not expected) error. We need to set minimal one default value,
-	// if there are no attributes in the input
+	// will return MalformedInput(message: End of list found where not expected) error.
+	// if there are no attributes in the input,
+	// We need to set minimal one default value, or use customUpdate to skip api call.
 	if len(input.Attributes) == 0 {
 		input.Attributes = map[string]*string{
 			"DelaySeconds": latest.ko.Spec.DelaySeconds,


### PR DESCRIPTION
Issue [#1969](https://github.com/aws-controllers-k8s/community/issues/1969)

Description of changes:
- set default delaySeconds if no attributes in the spec
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
