### PR TITLE
Correctly handle `NonExistentQueue` API error

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-02-14T04:05:34Z"
+  build_date: "2024-02-28T22:09:25Z"
   build_hash: 947081ffebdeefcf2c61c4ca6d7e68810bdf9d08
   go_version: go1.22.0
   version: v0.30.0
-api_directory_checksum: b608c6d71ba30c8b157197db292825f8c6317e22
+api_directory_checksum: f74a20965e9cd60cc5b02f43349da4f6cf29c865
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.0
 generator_config_info:
-  file_checksum: 9eac8d3730cfe212c3a88aa5173b22de93c2d0b7
+  file_checksum: c49468a6a7bcf784138740ec91fe96d1825fbe62
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -1,5 +1,9 @@
 resources:
   Queue:
+    exceptions:
+      errors:
+        404:
+          code: AWS.SimpleQueueService.NonExistentQueue
     unpack_attributes_map:
       set_attributes_single_attribute: false
       get_attributes_input:

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/sqs-controller
-  newTag: 1.0.9
+  newTag: 1.0.10

--- a/generator.yaml
+++ b/generator.yaml
@@ -1,5 +1,9 @@
 resources:
   Queue:
+    exceptions:
+      errors:
+        404:
+          code: AWS.SimpleQueueService.NonExistentQueue
     unpack_attributes_map:
       set_attributes_single_attribute: false
       get_attributes_input:

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: sqs-chart
 description: A Helm chart for the ACK service controller for Amazon Simple Queue Service (SQS)
-version: 1.0.9
-appVersion: 1.0.9
+version: 1.0.10
+appVersion: 1.0.10
 home: https://github.com/aws-controllers-k8s/sqs-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/sqs-controller:1.0.9".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/sqs-controller:1.0.10".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/sqs-controller
-  tag: 1.0.9
+  tag: 1.0.10
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/pkg/resource/queue/sdk.go
+++ b/pkg/resource/queue/sdk.go
@@ -76,7 +76,7 @@ func (rm *resourceManager) sdkFind(
 	resp, err = rm.sdkapi.GetQueueAttributesWithContext(ctx, input)
 	rm.metrics.RecordAPICall("GET_ATTRIBUTES", "GetQueueAttributes", err)
 	if err != nil {
-		if awsErr, ok := ackerr.AWSError(err); ok && awsErr.Code() == "UNKNOWN" {
+		if awsErr, ok := ackerr.AWSError(err); ok && awsErr.Code() == "AWS.SimpleQueueService.NonExistentQueue" {
 			return nil, ackerr.NotFound
 		}
 		return nil, err
@@ -300,7 +300,7 @@ func (rm *resourceManager) sdkUpdate(
 	_, respErr := rm.sdkapi.SetQueueAttributesWithContext(ctx, input)
 	rm.metrics.RecordAPICall("SET_ATTRIBUTES", "SetQueueAttributes", respErr)
 	if respErr != nil {
-		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "UNKNOWN" {
+		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "AWS.SimpleQueueService.NonExistentQueue" {
 			// Technically, this means someone deleted the backend resource in
 			// between the time we got a result back from sdkFind() and here...
 			return nil, ackerr.NotFound


### PR DESCRIPTION
Regenerate the controller with a new exception directive, that instruct
the controller to start treating `AWS.SimpleQueueService.NonExistentQueue`
error messages (known as Codes in aws-sdk-go) as 404 HTTP Status code.
This allow the controller to treat this error as a "resource not found"
case and trigger the recreation of the queue

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
