### PR TITLE
Update `Queue` generator config with late initialization and new attributes

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-10-10T04:03:34Z"
-  build_hash: 36c2d234498c2bc4f60773ab8df632af4067f43b
-  go_version: go1.23.2
-  version: v0.39.1
-api_directory_checksum: f74a20965e9cd60cc5b02f43349da4f6cf29c865
+  build_date: "2024-10-11T23:32:16Z"
+  build_hash: 5bdd3b9f4b9fb86d5b0c302eb80cdd9884217d35
+  go_version: go1.22.4
+  version: v0.38.1-5-g5bdd3b9
+api_directory_checksum: 0df08791de46be9f5503519df966986952e631e8
 api_version: v1alpha1
-aws_sdk_go_version: v1.49.0
+aws_sdk_go_version: v1.55.5
 generator_config_info:
-  file_checksum: c49468a6a7bcf784138740ec91fe96d1825fbe62
+  file_checksum: 1838c1a72ba461991a7fb9dbf9693ec1ec2c5a41
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/enums.go
+++ b/apis/v1alpha1/enums.go
@@ -18,6 +18,7 @@ package v1alpha1
 type MessageSystemAttributeName string
 
 const (
+	MessageSystemAttributeName_All                              MessageSystemAttributeName = "All"
 	MessageSystemAttributeName_SenderId                         MessageSystemAttributeName = "SenderId"
 	MessageSystemAttributeName_SentTimestamp                    MessageSystemAttributeName = "SentTimestamp"
 	MessageSystemAttributeName_ApproximateReceiveCount          MessageSystemAttributeName = "ApproximateReceiveCount"

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -22,12 +22,15 @@ resources:
       DelaySeconds:
         is_attribute: true
         type: string
+        late_initialize: {}
       MaximumMessageSize:
         is_attribute: true
         type: string
+        late_initialize: {}
       MessageRetentionPeriod:
         is_attribute: true
         type: string
+        late_initialize: {}
       KmsMasterKeyId:
         is_attribute: true
         type: string
@@ -36,6 +39,9 @@ resources:
           resource: Key
           path: Status.KeyID
       KmsDataKeyReusePeriodSeconds:
+        is_attribute: true
+        type: string
+      SqsManagedSseEnabled:
         is_attribute: true
         type: string
       Policy:
@@ -48,9 +54,11 @@ resources:
       ReceiveMessageWaitTimeSeconds:
         is_attribute: true
         type: string
+        late_initialize: {}
       VisibilityTimeout:
         is_attribute: true
         type: string
+        late_initialize: {}
       FifoQueue:
         is_attribute: true
         type: string

--- a/apis/v1alpha1/queue.go
+++ b/apis/v1alpha1/queue.go
@@ -37,6 +37,7 @@ type QueueSpec struct {
 	ReceiveMessageWaitTimeSeconds *string `json:"receiveMessageWaitTimeSeconds,omitempty"`
 	RedriveAllowPolicy            *string `json:"redriveAllowPolicy,omitempty"`
 	RedrivePolicy                 *string `json:"redrivePolicy,omitempty"`
+	SQSManagedSSEEnabled          *string `json:"sqsManagedSSEEnabled,omitempty"`
 	// Add cost allocation tags to the specified Amazon SQS queue. For an overview,
 	// see Tagging Your Amazon SQS Queues (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-queue-tags.html)
 	// in the Amazon SQS Developer Guide.

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -406,6 +406,11 @@ func (in *QueueSpec) DeepCopyInto(out *QueueSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SQSManagedSSEEnabled != nil {
+		in, out := &in.SQSManagedSSEEnabled, &out.SQSManagedSSEEnabled
+		*out = new(string)
+		**out = **in
+	}
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags
 		*out = make(map[string]*string, len(*in))

--- a/config/crd/bases/sqs.services.k8s.aws_queues.yaml
+++ b/config/crd/bases/sqs.services.k8s.aws_queues.yaml
@@ -97,6 +97,8 @@ spec:
                 type: string
               redrivePolicy:
                 type: string
+              sqsManagedSSEEnabled:
+                type: string
               tags:
                 additionalProperties:
                   type: string

--- a/generator.yaml
+++ b/generator.yaml
@@ -22,12 +22,15 @@ resources:
       DelaySeconds:
         is_attribute: true
         type: string
+        late_initialize: {}
       MaximumMessageSize:
         is_attribute: true
         type: string
+        late_initialize: {}
       MessageRetentionPeriod:
         is_attribute: true
         type: string
+        late_initialize: {}
       KmsMasterKeyId:
         is_attribute: true
         type: string
@@ -36,6 +39,9 @@ resources:
           resource: Key
           path: Status.KeyID
       KmsDataKeyReusePeriodSeconds:
+        is_attribute: true
+        type: string
+      SqsManagedSseEnabled:
         is_attribute: true
         type: string
       Policy:
@@ -48,9 +54,11 @@ resources:
       ReceiveMessageWaitTimeSeconds:
         is_attribute: true
         type: string
+        late_initialize: {}
       VisibilityTimeout:
         is_attribute: true
         type: string
+        late_initialize: {}
       FifoQueue:
         is_attribute: true
         type: string

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws-controllers-k8s/iam-controller v1.1.1
 	github.com/aws-controllers-k8s/kms-controller v1.0.2
 	github.com/aws-controllers-k8s/runtime v0.39.0
-	github.com/aws/aws-sdk-go v1.49.0
+	github.com/aws/aws-sdk-go v1.55.5
 	github.com/go-logr/logr v1.4.2
 	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/aws-controllers-k8s/kms-controller v1.0.2 h1:v8nh/oaX/U6spCwBDaWyem7X
 github.com/aws-controllers-k8s/kms-controller v1.0.2/go.mod h1:BeoijsyGjJ9G5VcDjpFdxBW0IxaeKXYX497XmUJiPSQ=
 github.com/aws-controllers-k8s/runtime v0.39.0 h1:IgOXluSzvb4UcDr9eU7SPw5MJnL7kt5R6DuF5Qu9zVQ=
 github.com/aws-controllers-k8s/runtime v0.39.0/go.mod h1:G07g26y1cxyZO6Ngp+LwXf03CqFyLNL7os4Py4IdyGY=
-github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
-github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
+github.com/aws/aws-sdk-go v1.55.5 h1:KKUZBfBoyqy5d3swXyiC7Q76ic40rYcbqH7qjh59kzU=
+github.com/aws/aws-sdk-go v1.55.5/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/helm/crds/sqs.services.k8s.aws_queues.yaml
+++ b/helm/crds/sqs.services.k8s.aws_queues.yaml
@@ -97,6 +97,8 @@ spec:
                 type: string
               redrivePolicy:
                 type: string
+              sqsManagedSSEEnabled:
+                type: string
               tags:
                 additionalProperties:
                   type: string

--- a/pkg/resource/queue/delta.go
+++ b/pkg/resource/queue/delta.go
@@ -133,6 +133,13 @@ func newResourceDelta(
 			delta.Add("Spec.RedrivePolicy", a.ko.Spec.RedrivePolicy, b.ko.Spec.RedrivePolicy)
 		}
 	}
+	if ackcompare.HasNilDifference(a.ko.Spec.SQSManagedSSEEnabled, b.ko.Spec.SQSManagedSSEEnabled) {
+		delta.Add("Spec.SQSManagedSSEEnabled", a.ko.Spec.SQSManagedSSEEnabled, b.ko.Spec.SQSManagedSSEEnabled)
+	} else if a.ko.Spec.SQSManagedSSEEnabled != nil && b.ko.Spec.SQSManagedSSEEnabled != nil {
+		if *a.ko.Spec.SQSManagedSSEEnabled != *b.ko.Spec.SQSManagedSSEEnabled {
+			delta.Add("Spec.SQSManagedSSEEnabled", a.ko.Spec.SQSManagedSSEEnabled, b.ko.Spec.SQSManagedSSEEnabled)
+		}
+	}
 	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}

--- a/pkg/resource/queue/manager.go
+++ b/pkg/resource/queue/manager.go
@@ -51,7 +51,7 @@ var (
 // +kubebuilder:rbac:groups=sqs.services.k8s.aws,resources=queues,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=sqs.services.k8s.aws,resources=queues/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{}
+var lateInitializeFieldNames = []string{"DelaySeconds", "MaximumMessageSize", "MessageRetentionPeriod", "ReceiveMessageWaitTimeSeconds", "VisibilityTimeout"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -248,6 +248,22 @@ func (rm *resourceManager) LateInitialize(
 func (rm *resourceManager) incompleteLateInitialization(
 	res acktypes.AWSResource,
 ) bool {
+	ko := rm.concreteResource(res).ko.DeepCopy()
+	if ko.Spec.DelaySeconds == nil {
+		return true
+	}
+	if ko.Spec.MaximumMessageSize == nil {
+		return true
+	}
+	if ko.Spec.MessageRetentionPeriod == nil {
+		return true
+	}
+	if ko.Spec.ReceiveMessageWaitTimeSeconds == nil {
+		return true
+	}
+	if ko.Spec.VisibilityTimeout == nil {
+		return true
+	}
 	return false
 }
 
@@ -257,7 +273,24 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 	observed acktypes.AWSResource,
 	latest acktypes.AWSResource,
 ) acktypes.AWSResource {
-	return latest
+	observedKo := rm.concreteResource(observed).ko.DeepCopy()
+	latestKo := rm.concreteResource(latest).ko.DeepCopy()
+	if observedKo.Spec.DelaySeconds != nil && latestKo.Spec.DelaySeconds == nil {
+		latestKo.Spec.DelaySeconds = observedKo.Spec.DelaySeconds
+	}
+	if observedKo.Spec.MaximumMessageSize != nil && latestKo.Spec.MaximumMessageSize == nil {
+		latestKo.Spec.MaximumMessageSize = observedKo.Spec.MaximumMessageSize
+	}
+	if observedKo.Spec.MessageRetentionPeriod != nil && latestKo.Spec.MessageRetentionPeriod == nil {
+		latestKo.Spec.MessageRetentionPeriod = observedKo.Spec.MessageRetentionPeriod
+	}
+	if observedKo.Spec.ReceiveMessageWaitTimeSeconds != nil && latestKo.Spec.ReceiveMessageWaitTimeSeconds == nil {
+		latestKo.Spec.ReceiveMessageWaitTimeSeconds = observedKo.Spec.ReceiveMessageWaitTimeSeconds
+	}
+	if observedKo.Spec.VisibilityTimeout != nil && latestKo.Spec.VisibilityTimeout == nil {
+		latestKo.Spec.VisibilityTimeout = observedKo.Spec.VisibilityTimeout
+	}
+	return &resource{latestKo}
 }
 
 // IsSynced returns true if the resource is synced.

--- a/pkg/resource/queue/sdk.go
+++ b/pkg/resource/queue/sdk.go
@@ -102,6 +102,7 @@ func (rm *resourceManager) sdkFind(
 	ko.Spec.ReceiveMessageWaitTimeSeconds = resp.Attributes["ReceiveMessageWaitTimeSeconds"]
 	ko.Spec.RedriveAllowPolicy = resp.Attributes["RedriveAllowPolicy"]
 	ko.Spec.RedrivePolicy = resp.Attributes["RedrivePolicy"]
+	ko.Spec.SQSManagedSSEEnabled = resp.Attributes["SqsManagedSseEnabled"]
 	ko.Spec.VisibilityTimeout = resp.Attributes["VisibilityTimeout"]
 
 	// If the QueueName field is empty, populate it with the last part of the queue ARN
@@ -236,6 +237,9 @@ func (rm *resourceManager) newCreateRequestPayload(
 	if r.ko.Spec.RedrivePolicy != nil {
 		attrMap["RedrivePolicy"] = r.ko.Spec.RedrivePolicy
 	}
+	if r.ko.Spec.SQSManagedSSEEnabled != nil {
+		attrMap["SqsManagedSseEnabled"] = r.ko.Spec.SQSManagedSSEEnabled
+	}
 	if r.ko.Spec.VisibilityTimeout != nil {
 		attrMap["VisibilityTimeout"] = r.ko.Spec.VisibilityTimeout
 	}
@@ -366,10 +370,15 @@ func (rm *resourceManager) newSetAttributesRequestPayload(
 	if r.ko.Spec.RedrivePolicy != nil {
 		attrMap["RedrivePolicy"] = r.ko.Spec.RedrivePolicy
 	}
+	if r.ko.Spec.SQSManagedSSEEnabled != nil {
+		attrMap["SqsManagedSseEnabled"] = r.ko.Spec.SQSManagedSSEEnabled
+	}
 	if r.ko.Spec.VisibilityTimeout != nil {
 		attrMap["VisibilityTimeout"] = r.ko.Spec.VisibilityTimeout
 	}
-	res.SetAttributes(attrMap)
+	if len(attrMap) > 0 {
+		res.SetAttributes(attrMap)
+	}
 	if r.ko.Status.QueueURL != nil {
 		res.SetQueueUrl(*r.ko.Status.QueueURL)
 	}


### PR DESCRIPTION
Fixes:
- https://github.com/aws-controllers-k8s/community/issues/1969
- https://github.com/aws-controllers-k8s/community/issues/2139
- https://github.com/aws-controllers-k8s/community/issues/1942

This patch regenerates the controller after modifying the `Queue` generator
config with the following changes:

1. Add late initialization for several attributes:
  - `DelaySeconds`
  - `MaximumMessageSize`
  - `MessageRetentionPeriod`
  - `ReceiveMessageWaitTimeSeconds`
  - `VisibilityTimeout`

These fields will now be populated from the AWS API if not specified by the user.

2. Add a new attribute:
  - `SQSManagedSseEnabled`

This allows users to enable or disable SQS managed server side encryption..

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
