### PR TITLE
feat(sqs): add printer columns for `Queue` CRD

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-10-11T23:32:16Z"
-  build_hash: 5bdd3b9f4b9fb86d5b0c302eb80cdd9884217d35
-  go_version: go1.22.4
-  version: v0.38.1-5-g5bdd3b9
-api_directory_checksum: 0df08791de46be9f5503519df966986952e631e8
+  build_date: "2024-10-24T02:20:42Z"
+  build_hash: 36c2d234498c2bc4f60773ab8df632af4067f43b
+  go_version: go1.23.2
+  version: v0.39.1
+api_directory_checksum: 8f26009577f13f96d7f6ba08a96e95f2f7f08b86
 api_version: v1alpha1
 aws_sdk_go_version: v1.55.5
 generator_config_info:
-  file_checksum: 1838c1a72ba461991a7fb9dbf9693ec1ec2c5a41
+  file_checksum: 662a51e8e4a1225d04aa0121d55827e0a9a054af
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -18,6 +18,30 @@ resources:
         template_path: hooks/queue/sdk_get_attributes_post_set_output.go.tpl
       sdk_update_pre_build_request:
         template_path: hooks/queue/sdk_update_pre_build_request.go.tpl
+    print:
+      add_age_column: true
+      add_synced_column: true
+      additional_columns:
+        - name: DelaySeconds
+          type: string
+          json_path: .spec.delaySeconds
+          priority: 0
+        - name: visibilityTimeout
+          type: string
+          json_path: .spec.visibilityTimeout
+          priority: 0
+        - name: maximumMessageSize
+          type: string
+          json_path: .spec.maximumMessageSize
+          priority: 1
+        - name: messageRetentionPeriod
+          type: string
+          json_path: .spec.messageRetentionPeriod
+          priority: 1
+        - name: receiveMessageWaitTimeSeconds
+          type: string
+          json_path: .spec.receiveMessageWaitTimeSeconds
+          priority: 1
     fields:
       DelaySeconds:
         is_attribute: true

--- a/apis/v1alpha1/queue.go
+++ b/apis/v1alpha1/queue.go
@@ -90,6 +90,13 @@ type QueueStatus struct {
 // Queue is the Schema for the Queues API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="DelaySeconds",type=string,priority=0,JSONPath=`.spec.delaySeconds`
+// +kubebuilder:printcolumn:name="maximumMessageSize",type=string,priority=1,JSONPath=`.spec.maximumMessageSize`
+// +kubebuilder:printcolumn:name="messageRetentionPeriod",type=string,priority=1,JSONPath=`.spec.messageRetentionPeriod`
+// +kubebuilder:printcolumn:name="receiveMessageWaitTimeSeconds",type=string,priority=1,JSONPath=`.spec.receiveMessageWaitTimeSeconds`
+// +kubebuilder:printcolumn:name="visibilityTimeout",type=string,priority=0,JSONPath=`.spec.visibilityTimeout`
+// +kubebuilder:printcolumn:name="Synced",type="string",priority=0,JSONPath=".status.conditions[?(@.type==\"ACK.ResourceSynced\")].status"
+// +kubebuilder:printcolumn:name="Age",type="date",priority=0,JSONPath=".metadata.creationTimestamp"
 type Queue struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/sqs.services.k8s.aws_queues.yaml
+++ b/config/crd/bases/sqs.services.k8s.aws_queues.yaml
@@ -14,7 +14,32 @@ spec:
     singular: queue
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.delaySeconds
+      name: DelaySeconds
+      type: string
+    - jsonPath: .spec.maximumMessageSize
+      name: maximumMessageSize
+      priority: 1
+      type: string
+    - jsonPath: .spec.messageRetentionPeriod
+      name: messageRetentionPeriod
+      priority: 1
+      type: string
+    - jsonPath: .spec.receiveMessageWaitTimeSeconds
+      name: receiveMessageWaitTimeSeconds
+      priority: 1
+      type: string
+    - jsonPath: .spec.visibilityTimeout
+      name: visibilityTimeout
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ACK.ResourceSynced")].status
+      name: Synced
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Queue is the Schema for the Queues API

--- a/generator.yaml
+++ b/generator.yaml
@@ -18,6 +18,30 @@ resources:
         template_path: hooks/queue/sdk_get_attributes_post_set_output.go.tpl
       sdk_update_pre_build_request:
         template_path: hooks/queue/sdk_update_pre_build_request.go.tpl
+    print:
+      add_age_column: true
+      add_synced_column: true
+      additional_columns:
+        - name: DelaySeconds
+          type: string
+          json_path: .spec.delaySeconds
+          priority: 0
+        - name: visibilityTimeout
+          type: string
+          json_path: .spec.visibilityTimeout
+          priority: 0
+        - name: maximumMessageSize
+          type: string
+          json_path: .spec.maximumMessageSize
+          priority: 1
+        - name: messageRetentionPeriod
+          type: string
+          json_path: .spec.messageRetentionPeriod
+          priority: 1
+        - name: receiveMessageWaitTimeSeconds
+          type: string
+          json_path: .spec.receiveMessageWaitTimeSeconds
+          priority: 1
     fields:
       DelaySeconds:
         is_attribute: true

--- a/helm/crds/sqs.services.k8s.aws_queues.yaml
+++ b/helm/crds/sqs.services.k8s.aws_queues.yaml
@@ -14,7 +14,32 @@ spec:
     singular: queue
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.delaySeconds
+      name: DelaySeconds
+      type: string
+    - jsonPath: .spec.maximumMessageSize
+      name: maximumMessageSize
+      priority: 1
+      type: string
+    - jsonPath: .spec.messageRetentionPeriod
+      name: messageRetentionPeriod
+      priority: 1
+      type: string
+    - jsonPath: .spec.receiveMessageWaitTimeSeconds
+      name: receiveMessageWaitTimeSeconds
+      priority: 1
+      type: string
+    - jsonPath: .spec.visibilityTimeout
+      name: visibilityTimeout
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ACK.ResourceSynced")].status
+      name: Synced
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Queue is the Schema for the Queues API


### PR DESCRIPTION
Adds printer columns to show Queue configuration at a glance:
- Default view: `DelaySeconds`, `visibilityTimeout`, `Age`, `Synced`
- Extended view (-o wide): `maximumMessageSize`, `messageRetentionPeriod`,
 `receiveMessageWaitTimeSeconds`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
