### PR TITLE
fix: add late_initialize for SqsManagedSseEnabled to prevent drift

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2026-06-22T23:06:54Z"
+  build_date: "2026-06-26T00:26:14Z"
   build_hash: 2ae5d2cfadaa2a10b2ccb9e73a111b2a91c36642
   go_version: go1.26.4
   version: v0.60.0
@@ -7,7 +7,7 @@ api_directory_checksum: 20f261849ce937cddcec136053077c5999094bc2
 api_version: v1alpha1
 aws_sdk_go_version: v1.34.0
 generator_config_info:
-  file_checksum: 77d7206f043ebf543b41b292a2a3e4ef148c33b1
+  file_checksum: ac1aa90c7cb9112eecc0314ddca196e4e7369d75
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -75,6 +75,8 @@ resources:
       SqsManagedSseEnabled:
         is_attribute: true
         type: string
+        late_initialize:
+          skip_incomplete_check: {}
       Policy:
         is_iam_policy: true
         is_attribute: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -75,6 +75,8 @@ resources:
       SqsManagedSseEnabled:
         is_attribute: true
         type: string
+        late_initialize:
+          skip_incomplete_check: {}
       Policy:
         is_iam_policy: true
         is_attribute: true

--- a/pkg/resource/queue/manager.go
+++ b/pkg/resource/queue/manager.go
@@ -50,7 +50,7 @@ var (
 // +kubebuilder:rbac:groups=sqs.services.k8s.aws,resources=queues,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=sqs.services.k8s.aws,resources=queues/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{"DelaySeconds", "MaximumMessageSize", "MessageRetentionPeriod", "ReceiveMessageWaitTimeSeconds", "VisibilityTimeout"}
+var lateInitializeFieldNames = []string{"DelaySeconds", "MaximumMessageSize", "MessageRetentionPeriod", "ReceiveMessageWaitTimeSeconds", "SQSManagedSSEEnabled", "VisibilityTimeout"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -289,6 +289,9 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 	}
 	if observedKo.Spec.ReceiveMessageWaitTimeSeconds != nil && latestKo.Spec.ReceiveMessageWaitTimeSeconds == nil {
 		latestKo.Spec.ReceiveMessageWaitTimeSeconds = observedKo.Spec.ReceiveMessageWaitTimeSeconds
+	}
+	if observedKo.Spec.SQSManagedSSEEnabled != nil && latestKo.Spec.SQSManagedSSEEnabled == nil {
+		latestKo.Spec.SQSManagedSSEEnabled = observedKo.Spec.SQSManagedSSEEnabled
 	}
 	if observedKo.Spec.VisibilityTimeout != nil && latestKo.Spec.VisibilityTimeout == nil {
 		latestKo.Spec.VisibilityTimeout = observedKo.Spec.VisibilityTimeout


### PR DESCRIPTION
Description of changes:
AWS defaults SQS managed SSE to enabled. Without late_initialize, the
controller detects a false delta (nil vs "true") and triggers unnecessary
reconciliation loops.

Resolves aws-controllers-k8s/community#2695

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
